### PR TITLE
Remove Playable Char Mod from modpack

### DIFF
--- a/MODS.csv
+++ b/MODS.csv
@@ -1,3 +1,2 @@
-playable-characters-mod,https://github.com/ja2-stracciatella/mod-playable-chars,40d9454097ac16476279993908ea3bcd3700cd40
 kaerar-gun-pack,https://github.com/ja2-stracciatella/mod-kaerar-gun-pack,2676449eee1e36dc994a9017337625eab6a0899e
 nightops-maps,https://github.com/ja2-stracciatella/mod-nightops-maps,9a4229550450d480e0bfa90b829bd718ca2f197e


### PR DESCRIPTION
The PCM mod has some glitches - e.g. weird pathing, chars sometimes not joining, and there are even reports of crashes.

I would say this mod does not add much value to game play (maybe more for the fun factor), so I would like to remove it from the modpack. The mod itself is still available in its own repo.

See also https://github.com/ja2-stracciatella/ja2-stracciatella/issues/1229, 